### PR TITLE
trixie-slim->trixieに修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for publishing
 # ARG VARIANT="14-buster"
-FROM node:22-trixie-slim
+FROM node:22-trixie
 
 RUN apt-get update && apt-get install -y zip
 


### PR DESCRIPTION
# Dockerfileのベースイメージを変更

`node:22-trixie-slim` → `node:22-trixie` に変更

## 理由
slimバージョンではGitが不足しており、GitHub Actionsでの実行時に問題が発生したため

## 確認事項
- GitHub Actions上でdeploy-pages.ymlでデプロイまでできることを動作確認済み